### PR TITLE
Do not run chown dojo home dir when uid/gid matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.4.1 (2019-Apr-29)
+* do not run chown dojo home dir when uid/gid matches
+
 ### 0.4.0 (2019-Apr-27)
 
 * added e2e tests on alpine and ubuntu18, executed in `inception-dojo` image

--- a/image_scripts/src/50-fix-uid-gid.sh
+++ b/image_scripts/src/50-fix-uid-gid.sh
@@ -43,9 +43,16 @@ fi
 # but on Alpine, there is no --numeric-uid-gid option
 newuid=$(ls -n -d "${dojo_work}" | awk '{ print $3 }')
 newgid=$(ls -n -d "${dojo_work}" | awk '{ print $4 }')
+olduid=$(ls -n -d ${dojo_home} | awk '{ print $3 }')
+oldgid=$(ls -n -d ${dojo_home} | awk '{ print $4 }')
 
 ( set -x; usermod -u "${newuid}" "${owner_username}"; groupmod -g "${newgid}" "${owner_groupname}"; )
-( set -x; chown ${newuid}:${newgid} -R "${dojo_home}"; )
+
+if [[ "${olduid}" == "${newuid}" ]] && [[ "${oldgid}" == "${newgid}" ]]; then
+    echo "No need to chown ${dojo_home}"
+else
+    ( set -x; chown ${newuid}:${newgid} -R "${dojo_home}"; )
+fi
 
 # do not chown the "$dojo_work" directory, it already has proper uid and gid,
-# besides, when "$dojo_work" is very big, chown would take much time
+# besides, when "$dojo_work" is very big, chown would take long time

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
-const DojoVersion = "0.4.0"
+const DojoVersion = "0.4.1"
 


### PR DESCRIPTION
This is a significant speedup in images with large caches in /home/dojo