### PR TITLE
Use the same environment variables when shell out and for envFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+### 0.4.2 (2019-Apr-30)
+
+* use the same environment variables when running a `docker run` or `docker-compose run` command and
+when generating the envFile
+
 ### 0.4.1 (2019-Apr-29)
+
 * do not run chown dojo home dir when uid/gid matches
 
 ### 0.4.0 (2019-Apr-27)

--- a/docker_compose_driver.go
+++ b/docker_compose_driver.go
@@ -321,7 +321,7 @@ func safelyCloseChannel(ch chan bool) (justClosed bool) {
 func (dc DockerComposeDriver) HandleRun(mergedConfig Config, runID string, envService EnvServiceInterface) int {
 	warnGeneral(dc.FileService, mergedConfig, envService, dc.Logger)
 	envFile := getEnvFilePath(runID, mergedConfig.Test)
-	saveEnvToFile(dc.FileService, envFile, mergedConfig.BlacklistVariables, envService.Variables())
+	saveEnvToFile(dc.FileService, envFile, mergedConfig.BlacklistVariables, envService.GetVariables())
 	dojoDCGeneratedFile, err := dc.handleDCFiles(mergedConfig)
 	if err != nil {
 		return 1

--- a/docker_compose_driver_test.go
+++ b/docker_compose_driver_test.go
@@ -286,7 +286,7 @@ func TestDockerComposeDriver_HandleRun_Unit(t *testing.T) {
 	config.Driver = "docker-compose"
 	config.RunCommand = "bla"
 	runID := "1234"
-	exitstatus := driver.HandleRun(config, runID, MockedEnvService{})
+	exitstatus := driver.HandleRun(config, runID, NewMockedEnvService())
 	assert.Equal(t, 0, exitstatus)
 	assert.Equal(t, 2, len(fs.FilesWrittenTo))
 	assert.Equal(t, "ABC=123\n", fs.FilesWrittenTo["/tmp/dojo-environment-1234"])
@@ -322,7 +322,7 @@ func TestDockerComposeDriver_HandleRun_RealFileService(t *testing.T) {
 	config.WorkDirOuter = "/tmp"
 	config.RunCommand = "bla"
 	runID := "1234"
-	exitstatus := driver.HandleRun(config, runID, MockedEnvService{})
+	exitstatus := driver.HandleRun(config, runID, NewMockedEnvService())
 	assert.Equal(t, 0, exitstatus)
 	exitstatus = driver.CleanAfterRun(config, runID)
 	assert.Equal(t, 0, exitstatus)
@@ -358,7 +358,7 @@ func TestDockerComposeDriver_HandleRun_RealEnvService(t *testing.T) {
 	config.WorkDirOuter = "/tmp"
 	config.RunCommand = "bla"
 	runID := "1234"
-	exitstatus := driver.HandleRun(config, runID, EnvService{})
+	exitstatus := driver.HandleRun(config, runID, NewEnvService())
 	assert.Equal(t, 0, exitstatus)
 	exitstatus = driver.CleanAfterRun(config, runID)
 	assert.Equal(t, 0, exitstatus)

--- a/docker_driver.go
+++ b/docker_driver.go
@@ -68,7 +68,7 @@ func (d DockerDriver) ConstructDockerRunCmd(config Config, envFilePath string, c
 func (d DockerDriver) HandleRun(mergedConfig Config, runID string, envService EnvServiceInterface) int {
 	warnGeneral(d.FileService, mergedConfig, envService, d.Logger)
 	envFile := getEnvFilePath(runID, mergedConfig.Test)
-	saveEnvToFile(d.FileService, envFile, mergedConfig.BlacklistVariables, envService.Variables())
+	saveEnvToFile(d.FileService, envFile, mergedConfig.BlacklistVariables, envService.GetVariables())
 
 	cmd := d.ConstructDockerRunCmd(mergedConfig, envFile, runID)
 	d.Logger.Log("info", green(fmt.Sprintf("docker command will be:\n %v", cmd)))

--- a/docker_driver_test.go
+++ b/docker_driver_test.go
@@ -105,7 +105,7 @@ func TestDockerDriver_HandleRun_Unit(t *testing.T) {
 	d := NewDockerDriver(NewMockedShellServiceNotInteractive(logger), fs, logger)
 	config := getTestConfig()
 	config.RunCommand = ""
-	es := d.HandleRun(config, "testrunid", MockedEnvService{})
+	es := d.HandleRun(config, "testrunid", NewMockedEnvService())
 	assert.Equal(t, 0, es)
 	assert.False(t, fileExists("/tmp/dojo-environment-testrunid"))
 	assert.Equal(t, 1, len(fs.FilesWrittenTo))
@@ -132,7 +132,7 @@ func TestDockerDriver_HandleRun_RealFileService(t *testing.T) {
 	config.WorkDirOuter = "/tmp"
 	config.RunCommand = ""
 	runID := "testrunid"
-	es := d.HandleRun(config, runID, EnvService{})
+	es := d.HandleRun(config, runID, NewEnvService())
 	assert.Equal(t, 0, es)
 	es = d.CleanAfterRun(config, runID)
 	assert.Equal(t, 0, es)
@@ -145,7 +145,7 @@ func TestDockerDriver_HandleRun_RealEnvService(t *testing.T) {
 	config := getTestConfig()
 	config.RunCommand = ""
 	runID := "testrunid"
-	es := d.HandleRun(config, runID, EnvService{})
+	es := d.HandleRun(config, runID, NewEnvService())
 	assert.Equal(t, 0, es)
 	es = d.CleanAfterRun(config, runID)
 	assert.Equal(t, 0, es)

--- a/environment_service.go
+++ b/environment_service.go
@@ -8,15 +8,33 @@ import (
 )
 
 type EnvServiceInterface interface {
-	Variables() []string
+	AddVariable(keyValue string)
 	IsCurrentUserRoot() bool
+	GetVariables() []string
 }
 
-type EnvService struct {}
-
-func (f EnvService) Variables() []string {
-	return os.Environ()
+type EnvService struct {
+	Variables []string
 }
+
+func (f EnvService) GetVariables() []string {
+	return f.Variables
+}
+
+func NewEnvService() *EnvService {
+	variables := make([]string, 0)
+	for _, value := range os.Environ() {
+		variables = append(variables, value)
+	}
+	return &EnvService{
+		Variables: variables,
+	}
+}
+
+func (f *EnvService) AddVariable(keyValue string){
+	f.Variables = append(f.Variables, keyValue)
+}
+
 func (f EnvService) IsCurrentUserRoot() bool {
 	currentUser, err := user.Current()
 	if err != nil {

--- a/environment_service_test.go
+++ b/environment_service_test.go
@@ -39,7 +39,7 @@ func Test_generateVariablesString(t *testing.T) {
 	// MYVAR is not blacklisted, is not set with DOJO_ prefix
 	// DOJO_VAR1 is not blacklisted, is set with DOJO_ prefix
 	// DISPLAY is always set to the same value
-	allVariables := []string{"USER=dojo", "BASH_123=123", "DOJO_USER=555", "MYVAR=999", "DOJO_VAR1=11", "USER1=1", "DISPLAY=aaa", "DOJO_USER1=2"}
+	allVariables := []string{"USER=dojo", "BASH_123=123", "DOJO_USER=555", "MYVAR=999", "DOJO_VAR1=11", "USER1=1", "DISPLAY=aaa", "DOJO_USER1=2", "DOJO_WORK_INNER=/my/dir"}
 	genStr := generateVariablesString(blacklisted, allVariables)
 	assert.Contains(t, genStr, "DOJO_USER=555\n")
 	assert.Contains(t, genStr, "DOJO_BASH_123=123\n")
@@ -47,15 +47,33 @@ func Test_generateVariablesString(t *testing.T) {
 	assert.Contains(t, genStr, "DOJO_VAR1=11\n")
 	assert.Contains(t, genStr, "DOJO_USER1=2\n")
 	assert.Contains(t, genStr, "DISPLAY=unix:0.0\n")
+	assert.Contains(t, genStr, "DOJO_WORK_INNER=/my/dir\n")
 	assert.NotContains(t, genStr, "DOJO_USER=dojo")
 	assert.NotContains(t, genStr, "USER1=1")
 	assert.NotContains(t, genStr, "DISPLAY=aaa")
 }
 
-type MockedEnvService struct {}
-func (f MockedEnvService) Variables() []string {
-	return []string{"ABC=123"}
+func Test_addVariable(t *testing.T) {
+	envService := NewEnvService()
+	envService.AddVariable("ABC=123")
+
+	assert.Contains(t, envService.Variables, "ABC=123")
+}
+
+type MockedEnvService struct {
+	Variables []string
+}
+func NewMockedEnvService() *MockedEnvService {
+	return &MockedEnvService{
+		Variables: []string{"ABC=123"},
+	}
+}
+func (f MockedEnvService) GetVariables() []string {
+	return f.Variables
 }
 func (f MockedEnvService) IsCurrentUserRoot() bool {
 	return false
+}
+func (f MockedEnvService) AddVariable(keyValue string){
+	f.Variables = append(f.Variables, keyValue)
 }

--- a/main.go
+++ b/main.go
@@ -80,11 +80,11 @@ func main() {
 		driver = NewDockerComposeDriver(shellService, fileService, logger)
 	}
 
-	envService := EnvService{}
-	newVariables := []string{
-		fmt.Sprintf("DOJO_WORK_INNER=%s", mergedConfig.WorkDirInner),
-		fmt.Sprintf("DOJO_WORK_OUTER=%s", mergedConfig.WorkDirOuter)}
-	shellService.SetEnvironment(envService.Variables(), newVariables)
+	envService := NewEnvService()
+	envService.AddVariable(fmt.Sprintf("DOJO_WORK_INNER=%s", mergedConfig.WorkDirInner))
+	envService.AddVariable(fmt.Sprintf("DOJO_WORK_OUTER=%s", mergedConfig.WorkDirOuter))
+
+	shellService.SetEnvironment(envService.GetVariables())
 
 	if mergedConfig.Action == "pull" {
 		exitstatus := driver.HandlePull(mergedConfig)

--- a/shell.go
+++ b/shell.go
@@ -19,8 +19,8 @@ type ShellServiceInterface interface {
 	// process the signaled return value.
 	RunGetOutput(cmdString string, separatePGroup bool) (string, string, int, bool)
 	CheckIfInteractive() bool
-	// set environment variables
-	SetEnvironment(currentVariables []string, additionalVariables []string)
+	// set environment variables, override any existing variables
+	SetEnvironment(variables []string)
 }
 
 func NewBashShellService(logger *Logger) *BashShellService {
@@ -38,12 +38,9 @@ type BashShellService struct {
 	Environment []string
 }
 
-func (bs *BashShellService) SetEnvironment(currentVariables []string, additionalVariables []string) {
+func (bs *BashShellService) SetEnvironment(variables []string) {
 	bs.Environment = make([]string, 0)
-	for _, value := range currentVariables {
-		bs.Environment = append(bs.Environment, value)
-	}
-	for _, value := range additionalVariables {
+	for _, value := range variables {
 		bs.Environment = append(bs.Environment, value)
 	}
 }

--- a/shell_test.go
+++ b/shell_test.go
@@ -19,9 +19,10 @@ func NewMockedShellServiceNotInteractive(logger *Logger) *MockedShellServiceNotI
 		Logger: logger,
 	}
 }
-func (bs MockedShellServiceNotInteractive) SetEnvironment(currentVariables []string, additionalVariables []string) {
-	for _, value := range additionalVariables {
-		bs.Environment = append(currentVariables, value)
+func (bs MockedShellServiceNotInteractive) SetEnvironment(variables []string) {
+	bs.Environment = make([]string, 0)
+	for _, value := range variables {
+		bs.Environment = append(bs.Environment, value)
 	}
 }
 func NewMockedShellServiceNotInteractive2(logger *Logger, commandsReactions map[string]interface{}) MockedShellServiceNotInteractive {
@@ -61,9 +62,10 @@ type MockedShellServiceInteractive struct {
 	Logger *Logger
 	Environment []string
 }
-func (bs MockedShellServiceInteractive) SetEnvironment(currentVariables []string, additionalVariables []string) {
-	for _, value := range additionalVariables {
-		bs.Environment = append(currentVariables, value)
+func (bs MockedShellServiceInteractive) SetEnvironment(variables []string) {
+	bs.Environment = make([]string, 0)
+	for _, value := range variables {
+		bs.Environment = append(bs.Environment, value)
 	}
 }
 func NewMockedShellServiceInteractive(logger *Logger) *MockedShellServiceInteractive {
@@ -114,9 +116,7 @@ func TestBashShellService_RunGetOutput(t *testing.T) {
 func TestBashShellService_SetEnv(t *testing.T) {
 	logger := NewLogger("debug")
 	shell := NewBashShellService(logger)
-	currEnv := []string{"ABC=123", "DEF=444"}
-	additionalEnv := []string{"ZZZ=999", "YYY=666"}
-	shell.SetEnvironment(currEnv, additionalEnv)
+	shell.SetEnvironment([]string{"ABC=123", "DEF=444", "ZZZ=999", "YYY=666"})
 	assert.Equal(t, 4, len(shell.Environment))
 	assert.Equal(t, "ABC=123", shell.Environment[0])
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
-const DojoVersion = "0.4.1"
+const DojoVersion = "0.4.2"
 


### PR DESCRIPTION
There is a bug that different environment variables are used when running a `docker run` or `docker-compose run` command and when creating the envFile. This PR makes Dojo use the same environment variables in both cases.